### PR TITLE
Feature/fis 421 unescape (#23) (#24)

### DIFF
--- a/lib/functions/get-all-historical-messages.js
+++ b/lib/functions/get-all-historical-messages.js
@@ -1,6 +1,7 @@
 const Db = require('../helpers/db')
 const FwisPlus = require('../models/fwisPlus')
 const Services = require('../helpers/services')
+const unescape = require('lodash.unescape')
 
 module.exports.handler = async (event) => {
   try {
@@ -16,6 +17,12 @@ module.exports.handler = async (event) => {
     const code = event.pathParameters.code
     const { rows } = await services.getAllHistoricalMessages(code)
     await db.end()
+
+    // unescape stuation text from the database
+    rows.forEach(rows => {
+      rows.situation = unescape(rows.situation)
+    })
+
     const fwis = new FwisPlus(rows)
     response.body = fwis.getJson()
 

--- a/lib/functions/get-all-messages.js
+++ b/lib/functions/get-all-messages.js
@@ -2,6 +2,7 @@ const Db = require('../helpers/db')
 const Services = require('../helpers/services')
 const Fwis = require('../models/fwis')
 const FwisPlus = require('../models/fwisPlus')
+const unescape = require('lodash.unescape')
 
 module.exports.handler = async (event) => {
   try {
@@ -17,6 +18,11 @@ module.exports.handler = async (event) => {
     await services.clearDownNoLongerInForce()
     const { rows } = await services.getAllMessages()
     await db.end()
+
+    // unescape stuation text from the database
+    rows.forEach(rows => {
+      rows.situation = unescape(rows.situation)
+    })
 
     const fwis = event.resource === '/fwis-plus.json' ? new FwisPlus(rows) : new Fwis(rows)
 

--- a/lib/models/message.js
+++ b/lib/models/message.js
@@ -13,10 +13,10 @@ class Message {
 
   async save (xmlResult, profile) {
     const message = {
-      targetAreaCode: escape(xmlResult.WarningMessage.TargetAreaCode[0]),
+      targetAreaCode: xmlResult.WarningMessage.TargetAreaCode[0],
       severity: ref[xmlResult.WarningMessage.SeverityLevel[0]],
       severityValue: refLevel[xmlResult.WarningMessage.SeverityLevel[0]],
-      situation: escape(xmlResult.WarningMessage.InternetSituation[0]),
+      situation: xmlResult.WarningMessage.InternetSituation[0],
       situationChanged: moment.tz(xmlResult.WarningMessage.$.approved, 'DD/MM/YYYY HH:mm', 'Europe/London').toISOString(),
       severityChanged: moment.tz(xmlResult.WarningMessage.$.approved, 'DD/MM/YYYY HH:mm', 'Europe/London').toISOString(),
       created: new Date().toISOString(),
@@ -29,6 +29,9 @@ class Message {
     // Validate Message
     const { error } = messageSchema.validate(message)
     if (error) throw new Error(error)
+
+    // escape situation text
+    message.situation = escape(message.situation)
 
     // get the last message
     message.lastMessage = (await this.services.getLastMessage(message.targetAreaCode)).rows[0]

--- a/package-lock.json
+++ b/package-lock.json
@@ -4182,6 +4182,11 @@
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
       "dev": true
     },
+    "lodash.unescape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
+    },
     "lolex": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "https-proxy-agent": "3.0.1",
     "js2xmlparser": "4.0.0",
     "lodash.escape": "^4.0.1",
+    "lodash.unescape": "^4.0.1",
     "moment": "2.24.0",
     "moment-timezone": "0.5.27",
     "pg": "7.14.0",

--- a/test/functions/get-all-historical-messages.js
+++ b/test/functions/get-all-historical-messages.js
@@ -39,7 +39,7 @@ lab.experiment('functions/get-all-historical-messages', () => {
     })
 
     const err = await Code.expect(handler(event)).to.reject()
-    Code.expect(err.message).to.equal('[500] rows.map is not a function')
+    Code.expect(err.message).to.equal('[500] rows.forEach is not a function')
   })
 
   lab.test('Sad: get historical messages throw error', async () => {

--- a/test/functions/process-message-happy.js
+++ b/test/functions/process-message-happy.js
@@ -200,4 +200,21 @@ lab.experiment('Notification API Client', () => {
     })
     Code.expect(response.statusCode).to.equal(200)
   })
+  lab.test(' 7 - testing situation text is escaped in the database', async () => {
+    sinon.stub(Services.prototype, 'getLastMessage').callsFake(() => {
+      return Promise.resolve({
+        rows: []
+      })
+    })
+
+    Services.prototype.putMessage.restore()
+    sinon.stub(Services.prototype, 'putMessage').callsFake((message) => {
+      Code.expect(message.situation).to.equal('&lt;script&gt;alert(&quot;This is an alert&quot;)&lt;/script&gt;')
+      return Promise.resolve({})
+    })
+    const response = await handler({
+      bodyXml: '<?xml version="1.0" encoding="UTF-8"?><WarningMessage xmlns="http://www.environment-agency.gov.uk/XMLSchemas/EAFWD" approved="01/02/2019 12:00" requestId="" language="English"><TargetAreaCode><![CDATA[111FWCECD022]]></TargetAreaCode><SeverityLevel>2</SeverityLevel><InternetSituation><![CDATA[<script>alert("This is an alert")</script>]]></InternetSituation><FWISGroupedTACodes><![CDATA[]]></FWISGroupedTACodes></WarningMessage>'
+    })
+    Code.expect(response.statusCode).to.equal(200)
+  })
 })


### PR DESCRIPTION
* Unescape characters

https://eaflood.atlassian.net/browse/FIS-421

* added function to unescape characters in situation coming from the database and moved the escaping to after the joi validation

* added unit test for escaping charaters on the database

* added unescape to get historical messages

* fixed unit tests for new code

Co-authored-by: nikiwycherley <niki.wycherley@environment-agency.gov.uk>