### PR TITLE
feature/NI-168-pin-localstack-version

### DIFF
--- a/docker/infrastructure.yml
+++ b/docker/infrastructure.yml
@@ -1,7 +1,7 @@
 services:
   localstack:
     container_name: "localstack-main"
-    image: localstack/localstack:latest
+    image: localstack/localstack:4.14.0
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway
       - "127.0.0.1:4510-4559:4510-4559"  # external services port range


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/NI-168

Use the final version of LocalStack community edition while alternatives are considered (see https://blog.localstack.cloud/localstack-for-aws-release-2026-03-0/)